### PR TITLE
feat(packaging): improve Windows and macOS desktop deliverables

### DIFF
--- a/.github/workflows/desktop-packaging.yml
+++ b/.github/workflows/desktop-packaging.yml
@@ -65,7 +65,7 @@ jobs:
             os-label: macOS
             artifact-name: svg-to-drawio-macos
             platform-family: macos
-            package-arch: x64
+            package-arch: universal2
             build-linux-installers: false
             build-windows-installer: false
 
@@ -159,6 +159,7 @@ jobs:
             packaging/linux/build_flatpak.sh \
             packaging/linux/prune_bundle.sh \
             packaging/linux/smoke_test_artifacts.sh \
+            packaging/macos/build_dmg.sh \
             packaging/macos/smoke_test_artifacts.sh
 
       - name: Build Windows installer
@@ -254,13 +255,13 @@ jobs:
             "${{ steps.version.outputs.value }}" \
             "dist/release/svg-to-drawio-${{ steps.version.outputs.value }}-linux-${FLATPAK_ARCH}.flatpak"
 
-      - name: Archive bundle (Windows)
+      - name: Copy portable executable (Windows)
         if: matrix.platform-family == 'windows'
         shell: pwsh
         run: >
-          Compress-Archive
-          -Path dist\desktop\svg-to-drawio.exe
-          -DestinationPath dist\release\svg-to-drawio-${{ steps.version.outputs.value }}-windows-${{ matrix.package-arch }}.zip
+          Copy-Item
+          -LiteralPath dist\desktop\svg-to-drawio.exe
+          -Destination dist\release\svg-to-drawio-${{ steps.version.outputs.value }}-windows-${{ matrix.package-arch }}.exe
 
       - name: Archive bundle (Linux)
         if: matrix.platform-family == 'linux'
@@ -275,9 +276,10 @@ jobs:
         if: matrix.platform-family == 'macos'
         shell: bash
         run: |
-          ditto -c -k --sequesterRsrc --keepParent \
-            dist/desktop/svg-to-drawio.app \
-            "dist/release/svg-to-drawio-${{ steps.version.outputs.value }}-macos.zip"
+          bash packaging/macos/build_dmg.sh \
+            "dist/desktop/SVG to draw.io.app" \
+            "${{ steps.version.outputs.value }}" \
+            "dist/release/svg-to-drawio-${{ steps.version.outputs.value }}-macos.dmg"
 
       - name: Smoke-test packaged Linux deliverables
         if: matrix.platform-family == 'linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-06-20
+
+### Changed
+
+- Windows portable desktop release artifacts now ship as direct `.exe` files instead of `.zip` archives.
+- macOS desktop release artifacts now ship as universal2 `.dmg` disk images instead of `macos.zip` archives, and the app bundle now uses the Finder-friendly name `SVG to draw.io.app`.
+
 ## [3.7.0] - 2026-06-19
 
 ### Added
@@ -141,7 +148,8 @@ All notable changes to this project are documented here. The format follows [Kee
 
 - Initial release: SVG to draw.io conversion engine.
 
-[Unreleased]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.7.0...HEAD
+[Unreleased]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.8.0...HEAD
+[3.8.0]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.5.1...v3.6.0
 [3.5.1]: https://github.com/V1rg1lee/svg-to-drawio/compare/v3.5.0...v3.5.1

--- a/README.md
+++ b/README.md
@@ -79,21 +79,21 @@ For anyone who would rather drag, drop, and click than type commands. The deskto
 
 Download a release artifact from the [Releases page](https://github.com/V1rg1lee/svg-to-drawio/releases):
 
-- Windows: `x64` and `ARM64` builds, each available as a `Setup.exe` installer or a plain `.zip`
+- Windows: `x64` and `ARM64` builds, each available as a `Setup.exe` installer or a direct portable `.exe`
 - Linux: `x64` and `ARM64` builds across `.deb`, `.rpm`, `.flatpak`, portable `.AppImage`, and plain `.tar.gz`
-- macOS: `.zip` archive of the app bundle
+- macOS: universal2 `.dmg` disk image for Apple Silicon and Intel Macs
 
 | Platform | Architecture | Recommended download | Other available formats |
 |---|---|---|---|
-| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.zip` |
-| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.zip` |
+| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.exe` |
+| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.exe` |
 | Linux (Debian / Ubuntu family) | `x64` | `linux-amd64.deb` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Debian / Ubuntu family) | `ARM64` | `linux-arm64.deb` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `x64` | `linux-x86_64.rpm` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `ARM64` | `linux-aarch64.rpm` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (cross-distro) | `x64` | `linux-x86_64.flatpak` | `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (cross-distro) | `ARM64` | `linux-aarch64.flatpak` | `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
-| macOS | bundled app archive | `macos.zip` | none |
+| macOS | `universal2` | `macos.dmg` | none |
 
 Features: drag-and-drop, multi-root queues, live progress, cooperative cancellation, safe close / force close, one-click output folder access, watch mode, persistent preferences, rendering presets, copy-as-CLI command, a plain-English compatibility panel with clickable details, and JSON report export.
 
@@ -450,9 +450,9 @@ This produces:
 
 - `dist/desktop/svg-to-drawio.exe` on Windows
 - `dist/desktop/svg-to-drawio` on Linux
-- `dist/desktop/svg-to-drawio.app` on macOS
+- `dist/desktop/SVG to draw.io.app` on macOS
 
-On Windows, the plain `.zip` archive keeps this default portable `onefile` build. The `Setup.exe` installer uses a separate `onedir` bundle so the installed app starts faster once deployed.
+On Windows, the portable release asset is the default `onefile` executable directly. The `Setup.exe` installer uses a separate `onedir` bundle so the installed app starts faster once deployed.
 
 Extra packaging layers are built on top of that base bundle:
 
@@ -461,7 +461,7 @@ Extra packaging layers are built on top of that base bundle:
 - Linux RPM package: `packaging/linux/build_rpm_in_fedora_container.sh` + `packaging/linux/build_rpm.sh`
 - Linux Flatpak bundle: `packaging/linux/build_flatpak.sh`
 - Linux AppImage: `packaging/linux/build_appimage.sh`
-- macOS: archive only for now
+- macOS DMG: `packaging/macos/build_dmg.sh`
 
 **Windows installer**
 
@@ -649,6 +649,24 @@ The recommended Linux download depends on the distro:
 - Use `.flatpak` when you want the same install flow across many different distros
 - Use `.AppImage` when you prefer a portable single-file app
 - Use `.tar.gz` only if you specifically want the raw bundle
+
+**macOS DMG**
+
+Build the base app bundle first, then wrap it in a disk image:
+
+```bash
+python -m pip install -r requirements-desktop.txt
+python build_desktop.py
+VERSION="$(python -c 'from svg_to_drawio import __version__; print(__version__)')"
+bash packaging/macos/build_dmg.sh \
+  "dist/desktop/SVG to draw.io.app" \
+  "$VERSION" \
+  "dist/release/svg-to-drawio-${VERSION}-macos.dmg"
+```
+
+This produces a universal2 macOS app bundle wrapped in a DMG:
+
+- `dist/release/svg-to-drawio-<version>-macos.dmg`
 
 Release assets now spell out the CPU family in the filename as well, for example `windows-x64`, `windows-arm64`, `linux-amd64`, `linux-arm64`, `linux-x86_64`, or `linux-aarch64` depending on the native package format.
 

--- a/build_desktop.py
+++ b/build_desktop.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import platform
 import subprocess
 import sys
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
+
+DEFAULT_APP_NAME = "svg-to-drawio"
+MACOS_APP_NAME = "SVG to draw.io"
 
 
 def _add_data_argument(source: Path, destination: str) -> str:
@@ -30,6 +34,15 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default="dist/desktop",
         help="Output directory for the built bundle, relative to the repository root by default.",
     )
+    parser.add_argument(
+        "--macos-target-arch",
+        choices=("auto", "x86_64", "arm64", "universal2"),
+        default="auto",
+        help=(
+            "macOS-only PyInstaller target architecture. Defaults to universal2 on macOS "
+            "and is ignored on other platforms."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -38,7 +51,21 @@ def _resolve_bundle_mode(bundle_mode: str) -> str:
     if bundle_mode != "auto":
         return bundle_mode
     # macOS requires a .app bundle; Windows/Linux default to a portable onefile build.
-    return "onedir" if sys.platform == "darwin" else "onefile"
+    return "onedir" if platform.system() == "Darwin" else "onefile"
+
+
+def _resolve_app_name() -> str:
+    """Return the user-facing bundle or executable name for the current platform."""
+    return MACOS_APP_NAME if platform.system() == "Darwin" else DEFAULT_APP_NAME
+
+
+def _resolve_macos_target_arch(target_arch: str) -> str | None:
+    """Resolve the effective PyInstaller macOS target architecture."""
+    if platform.system() != "Darwin":
+        return None
+    if target_arch != "auto":
+        return target_arch
+    return "universal2"
 
 
 def _resolve_path(project_root: Path, raw_path: str) -> Path:
@@ -89,6 +116,8 @@ def main(argv: Sequence[str] | None = None) -> None:
     options = _parse_args(argv)
     project_root = Path(__file__).resolve().parent
     bundle_mode = _resolve_bundle_mode(options.bundle_mode)
+    app_name = _resolve_app_name()
+    macos_target_arch = _resolve_macos_target_arch(options.macos_target_arch)
     build_root = project_root / "build" / "pyinstaller" / bundle_mode
     dist_root = _resolve_path(project_root, options.dist_dir)
     assets_dir = project_root / "svg_to_drawio_desktop" / "assets"
@@ -100,7 +129,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         "--windowed",
         f"--{bundle_mode}",
         "--name",
-        "svg-to-drawio",
+        app_name,
         "--paths",
         str(project_root),
         "--distpath",
@@ -140,6 +169,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         if icns_path and icns_path.is_file():
             args.extend(["--icon", str(icns_path)])
         args.extend(["--osx-bundle-identifier", "io.github.v1rg1lee.svg-to-drawio"])
+        if macos_target_arch is not None:
+            args.extend(["--target-arch", macos_target_arch])
 
     # Linux: PyInstaller ignores --icon; the icon is set at runtime via Qt's setWindowIcon.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,21 +34,21 @@ For anyone who would rather drag, drop, and click than type commands. The deskto
 
 Download a release artifact from the [Releases page](https://github.com/V1rg1lee/svg-to-drawio/releases):
 
-- Windows: `x64` and `ARM64` builds, each available as a `Setup.exe` installer or a plain `.zip`
+- Windows: `x64` and `ARM64` builds, each available as a `Setup.exe` installer or a direct portable `.exe`
 - Linux: `x64` and `ARM64` builds across `.deb`, `.rpm`, `.flatpak`, portable `.AppImage`, and plain `.tar.gz`
-- macOS: `.zip` archive of the app bundle
+- macOS: universal2 `.dmg` disk image for Apple Silicon and Intel Macs
 
 | Platform | Architecture | Recommended download | Other available formats |
 |---|---|---|---|
-| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.zip` |
-| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.zip` |
+| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.exe` |
+| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.exe` |
 | Linux (Debian / Ubuntu family) | `x64` | `linux-amd64.deb` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Debian / Ubuntu family) | `ARM64` | `linux-arm64.deb` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `x64` | `linux-x86_64.rpm` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `ARM64` | `linux-aarch64.rpm` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (cross-distro) | `x64` | `linux-x86_64.flatpak` | `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (cross-distro) | `ARM64` | `linux-aarch64.flatpak` | `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
-| macOS | bundled app archive | `macos.zip` | none |
+| macOS | `universal2` | `macos.dmg` | none |
 
 Features: drag-and-drop, multi-root queues, live progress, cooperative cancellation, safe close / force close, one-click output folder access, watch mode, persistent preferences, rendering presets, copy-as-CLI command, a plain-English compatibility panel with clickable details, and JSON report export.
 

--- a/docs/release-downloads.md
+++ b/docs/release-downloads.md
@@ -6,24 +6,25 @@ The desktop app uses the exact same conversion engine as the CLI and Python API.
 
 | Platform | Architecture | Recommended download | Other available formats |
 |---|---|---|---|
-| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.zip` |
-| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.zip` |
+| Windows | `x64` | `windows-x64-setup.exe` | `windows-x64.exe` |
+| Windows | `ARM64` | `windows-arm64-setup.exe` | `windows-arm64.exe` |
 | Linux (Debian / Ubuntu family) | `x64` | `linux-amd64.deb` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Debian / Ubuntu family) | `ARM64` | `linux-arm64.deb` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `x64` | `linux-x86_64.rpm` | `linux-x86_64.flatpak`, `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (Fedora / openSUSE / RHEL-like) | `ARM64` | `linux-aarch64.rpm` | `linux-aarch64.flatpak`, `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
 | Linux (cross-distro) | `x64` | `linux-x86_64.flatpak` | `linux-x64.AppImage`, `linux-x64.tar.gz` |
 | Linux (cross-distro) | `ARM64` | `linux-aarch64.flatpak` | `linux-arm64.AppImage`, `linux-arm64.tar.gz` |
-| macOS | bundled app archive | `macos.zip` | none |
+| macOS | `universal2` | `macos.dmg` | none |
 
 ## Short guidance
 
-- Choose `Setup.exe` on Windows unless you explicitly want a portable zip.
+- Choose `Setup.exe` on Windows unless you explicitly want the portable standalone `.exe`.
 - Choose `.deb` on Debian, Ubuntu, Linux Mint, Pop!_OS, and close derivatives.
 - Choose `.rpm` on Fedora, openSUSE, and RHEL-like systems.
 - Choose `.flatpak` when you want a cross-distro Linux install flow.
 - Choose `.AppImage` when you prefer a single portable Linux file instead of an installed package.
 - Choose `.tar.gz` only if you specifically want the raw extracted bundle.
+- Choose `macos.dmg` on macOS for the standard drag-and-drop install flow. The bundle is built as universal2 so one download works on both Apple Silicon and Intel Macs.
 
 ## Release verification
 

--- a/packaging/macos/build_dmg.sh
+++ b/packaging/macos/build_dmg.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 <app-bundle> <version> <output-dmg>" >&2
+    exit 1
+fi
+
+APP_BUNDLE="$1"
+VERSION="$2"
+OUTPUT_DMG="$3"
+
+if [[ ! -d "$APP_BUNDLE" || "${APP_BUNDLE##*.}" != "app" ]]; then
+    echo "Expected a macOS .app bundle, got: $APP_BUNDLE" >&2
+    exit 1
+fi
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+    echo "hdiutil is required to build a macOS DMG." >&2
+    exit 1
+fi
+
+APP_NAME="$(basename "$APP_BUNDLE")"
+VOLUME_NAME="SVG to draw.io"
+
+work_root="$(mktemp -d)"
+staging_dir="$work_root/staging"
+trap 'rm -rf "$work_root"' EXIT
+
+mkdir -p "$staging_dir"
+cp -R "$APP_BUNDLE" "$staging_dir/$APP_NAME"
+ln -s /Applications "$staging_dir/Applications"
+
+mkdir -p "$(dirname "$OUTPUT_DMG")"
+rm -f "$OUTPUT_DMG"
+
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$staging_dir" \
+    -ov \
+    -format UDZO \
+    "$OUTPUT_DMG" >/dev/null
+
+echo "Built macOS DMG for SVG to draw.io $VERSION at $OUTPUT_DMG"

--- a/packaging/macos/smoke_test_artifacts.sh
+++ b/packaging/macos/smoke_test_artifacts.sh
@@ -9,17 +9,24 @@ fi
 VERSION="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-ZIP_PATH="$REPO_ROOT/dist/release/svg-to-drawio-$VERSION-macos.zip"
-APP_EXECUTABLE="$REPO_ROOT/dist/desktop/svg-to-drawio.app/Contents/MacOS/svg-to-drawio"
+DMG_PATH="$REPO_ROOT/dist/release/svg-to-drawio-$VERSION-macos.dmg"
+APP_BUNDLE_NAME="SVG to draw.io.app"
+APP_EXECUTABLE_NAME="SVG to draw.io"
+APP_EXECUTABLE="$REPO_ROOT/dist/desktop/$APP_BUNDLE_NAME/Contents/MacOS/$APP_EXECUTABLE_NAME"
 
-if [[ ! -x "$APP_EXECUTABLE" || ! -f "$ZIP_PATH" ]]; then
+if [[ ! -x "$APP_EXECUTABLE" || ! -f "$DMG_PATH" ]]; then
     echo "macOS smoke-test artifacts are incomplete." >&2
     exit 1
 fi
 
 "$APP_EXECUTABLE" --smoke-test
 
-work_root="$(mktemp -d)"
-trap 'rm -rf "$work_root"' EXIT
-ditto -x -k "$ZIP_PATH" "$work_root"
-"$work_root/svg-to-drawio.app/Contents/MacOS/svg-to-drawio" --smoke-test
+mount_point="$(mktemp -d)"
+cleanup() {
+    hdiutil detach "$mount_point" -quiet >/dev/null 2>&1 || true
+    rm -rf "$mount_point"
+}
+trap cleanup EXIT
+
+hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$mount_point" >/dev/null
+"$mount_point/$APP_BUNDLE_NAME/Contents/MacOS/$APP_EXECUTABLE_NAME" --smoke-test

--- a/packaging/windows/smoke_test_artifacts.ps1
+++ b/packaging/windows/smoke_test_artifacts.ps1
@@ -28,28 +28,23 @@ function Invoke-SmokeTestExecutable {
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $releaseDir = Join-Path $repoRoot "dist\release"
-$zipPath = Join-Path $releaseDir "svg-to-drawio-$Version-windows-$PackageArchitecture.zip"
+$portableExePath = Join-Path $releaseDir "svg-to-drawio-$Version-windows-$PackageArchitecture.exe"
 $setupPath = Join-Path $releaseDir "svg-to-drawio-$Version-windows-$PackageArchitecture-setup.exe"
 
-if (-not (Test-Path $zipPath)) {
-    throw "Windows ZIP artifact not found: $zipPath"
+if (-not (Test-Path $portableExePath)) {
+    throw "Windows portable executable artifact not found: $portableExePath"
 }
 if (-not (Test-Path $setupPath)) {
     throw "Windows setup artifact not found: $setupPath"
 }
 
-$extractRoot = Join-Path $env:RUNNER_TEMP "svg-to-drawio-zip-$PackageArchitecture"
 $installRoot = Join-Path $env:RUNNER_TEMP "svg-to-drawio-installed-$PackageArchitecture"
 
-if (Test-Path $extractRoot) {
-    Remove-Item -LiteralPath $extractRoot -Recurse -Force
-}
 if (Test-Path $installRoot) {
     Remove-Item -LiteralPath $installRoot -Recurse -Force
 }
 
-Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
-Invoke-SmokeTestExecutable -ExecutablePath (Join-Path $extractRoot "svg-to-drawio.exe")
+Invoke-SmokeTestExecutable -ExecutablePath $portableExePath
 
 $installer = Start-Process `
     -FilePath $setupPath `

--- a/svg_to_drawio/__init__.py
+++ b/svg_to_drawio/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from os import PathLike
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"
 
 from .capabilities import all_capabilities, capability_descriptor, capability_keys, rendering_preflight_lines
 from .compatibility import CompatibilityOverview, CompatibilityRow, FeatureObservation

--- a/tests/unit/test_build_desktop.py
+++ b/tests/unit/test_build_desktop.py
@@ -1,0 +1,36 @@
+"""Regression tests for desktop bundle naming and macOS build targeting."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import build_desktop
+
+
+class BuildDesktopTests(unittest.TestCase):
+    """Verify platform-specific desktop bundle defaults."""
+
+    def test_default_name_is_cli_friendly_off_macos(self) -> None:
+        """Non-macOS platforms keep the package-style executable name."""
+        with patch.object(build_desktop.platform, "system", return_value="Windows"):
+            self.assertEqual(build_desktop._resolve_app_name(), "svg-to-drawio")
+
+    def test_macos_name_is_human_friendly(self) -> None:
+        """macOS uses a Finder-friendly app bundle name without hyphens."""
+        with patch.object(build_desktop.platform, "system", return_value="Darwin"):
+            self.assertEqual(build_desktop._resolve_app_name(), "SVG to draw.io")
+
+    def test_macos_auto_target_arch_defaults_to_universal2(self) -> None:
+        """macOS auto-targeting should produce one universal build for Intel and ARM."""
+        with patch.object(build_desktop.platform, "system", return_value="Darwin"):
+            self.assertEqual(build_desktop._resolve_macos_target_arch("auto"), "universal2")
+
+    def test_non_macos_ignores_macos_target_arch(self) -> None:
+        """Non-macOS builds should not emit a PyInstaller macOS target override."""
+        with patch.object(build_desktop.platform, "system", return_value="Linux"):
+            self.assertIsNone(build_desktop._resolve_macos_target_arch("universal2"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What and why

Improve desktop release deliverables on Windows and macOS.

This PR updates the packaging pipeline so Windows portable releases are published as direct standalone `.exe` files instead of `.zip` archives, and macOS releases are published as universal2 `.dmg` disk images instead of plain app archives. It also renames the macOS app bundle to the more Finder-friendly `SVG to draw.io.app`.

The goal is to make release downloads more natural for end users:
- Windows portable users can download and run the executable directly
- macOS users get a more standard DMG install flow
- the macOS bundle works across both Apple Silicon and Intel Macs with one artifact

The CI smoke tests and release documentation were updated accordingly so the new deliverables stay validated and clearly documented.

## Checklist

- [x] `python -m unittest discover -s tests -v` passes
- [x] `python -m ruff check main.py svg_to_drawio svg_to_drawio_desktop tests` is clean
- [x] `python -m mypy` is clean
- [ ] If conversion output changed: fixtures regenerated with `python -m tests.regenerate_fixtures` and the reason is explained below
- [x] If a CLI flag, Python API function, or default behavior changed: `README.md` is updated
- [x] If a CLI flag, Python API function, or default behavior changed: the relevant GitHub Pages doc under `docs/` (`quickstart.md`, `cli.md`, `python-api.md`, `advanced-rendering.md`) is updated and builds with `python scripts/build_docs.py build --strict`

## Fixture / behavior changes (if any)

No SVG conversion fixture changes were required. This PR changes desktop packaging outputs and release artifacts only.