### PR TITLE
feat: bump version number

### DIFF
--- a/svg_to_drawio/__init__.py
+++ b/svg_to_drawio/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from os import PathLike, fspath, path
 
-__version__ = "3.10.0"
+__version__ = "3.10.1"
 
 from .capabilities import all_capabilities, capability_descriptor, capability_keys, rendering_preflight_lines
 from .compatibility import CompatibilityOverview, CompatibilityRow, FeatureObservation


### PR DESCRIPTION
## What and why

version bump

## Checklist

- [x] `python -m unittest discover -s tests -v` passes
- [x] `python -m ruff check main.py svg_to_drawio svg_to_drawio_desktop tests` is clean
- [x] `python -m mypy` is clean
- [ ] If conversion output changed: fixtures regenerated with `python -m tests.regenerate_fixtures` and the reason is explained below
- [ ] If a CLI flag, Python API function, or default behavior changed: `README.md` is updated
- [ ] If a CLI flag, Python API function, or default behavior changed: the relevant GitHub Pages doc under `docs/` (`quickstart.md`, `cli.md`, `python-api.md`, `advanced-rendering.md`) is updated and builds with `python scripts/build_docs.py build --strict`

## Fixture / behavior changes (if any)

/ 