### PR TITLE
Fix/post aikido security regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           echo "Changed files since $BASE_SHA:"
           echo "$changed_files"
 
-          pattern='^(svg_to_drawio/|svg_to_drawio_desktop/|packaging/|build_desktop\.py|desktop_app\.py|requirements-desktop\.txt|pyproject\.toml|\.github/workflows/desktop-packaging\.yml|\.github/workflows/ci\.yml)'
+          pattern='^(svg_to_drawio/|svg_to_drawio_desktop/|packaging/|build_desktop\.py|desktop_app\.py|requirements-desktop\.txt|pyproject\.toml|\.github/workflows/desktop-build\.yml|\.github/workflows/desktop-packaging\.yml|\.github/workflows/ci\.yml)'
           if echo "$changed_files" | grep -qE "$pattern"; then
             echo "Desktop-relevant change detected; running desktop packaging."
             echo "desktop=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -23,39 +23,13 @@ jobs:
       RELEASE_GPG_PRIVATE_KEY: ${{ github.event_name == 'release' && secrets.RELEASE_GPG_PRIVATE_KEY || '' }}
       RELEASE_GPG_PASSPHRASE: ${{ github.event_name == 'release' && secrets.RELEASE_GPG_PASSPHRASE || '' }}
 
-  publish:
-    name: Publish release artifacts
-    runs-on: ubuntu-24.04
-    needs: build
-    if: github.event_name == 'release'
-    permissions:
-      contents: write
-    steps:
-      # Pinned to commit SHA to prevent tag-rewrite supply-chain attacks.
-      - name: Download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          pattern: svg-to-drawio-*
-          merge-multiple: true
-          path: dist/release
-
-      # gh CLI is pre-installed on all GitHub-hosted runners - no third-party action needed.
-      - name: Attach release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          cd dist/release
-          gh release upload "$RELEASE_TAG" --repo "$GH_REPO" --clobber *
-
   sign:
     name: Sign release artifacts
     runs-on: ubuntu-24.04
     needs: build
     if: github.event_name == 'release'
     permissions:
-      contents: write
+      contents: read
       id-token: write
 
     steps:
@@ -241,29 +215,29 @@ jobs:
             dist/release/SHA256SUMS.txt.asc
             dist/release/svg-to-drawio-release-signing-key.asc
 
-      - name: Attach signature assets
-        if: github.event_name == 'release'
-        shell: bash
+  publish:
+    name: Publish release artifacts
+    runs-on: ubuntu-24.04
+    needs: sign
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      # Download both the build artifacts and the verification artifacts produced by sign.
+      # Pinned to commit SHA to prevent tag-rewrite supply-chain attacks.
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: svg-to-drawio-*
+          merge-multiple: true
+          path: dist/release
+
+      # gh CLI is pre-installed on all GitHub-hosted runners - no third-party action needed.
+      - name: Attach release assets
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          shopt -s nullglob
           cd dist/release
-
-          assets=(
-            SHA256SUMS.txt
-            SHA256SUMS.txt.sigstore.json
-            *-verification-bundles.zip
-          )
-
-          if [[ -f SHA256SUMS.txt.asc ]]; then
-            assets+=(SHA256SUMS.txt.asc)
-          fi
-
-          if [[ -f svg-to-drawio-release-signing-key.asc ]]; then
-            assets+=(svg-to-drawio-release-signing-key.asc)
-          fi
-
-          gh release upload "$RELEASE_TAG" --repo "$GH_REPO" --clobber "${assets[@]}"
+          gh release upload "$RELEASE_TAG" --repo "$GH_REPO" --clobber *

--- a/README.md
+++ b/README.md
@@ -660,12 +660,11 @@ case "$APPIMAGE_ARCH" in
     EXPECTED_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
     ;;
   aarch64)
-    # Note: Checksum for aarch64 release 13 - verify at the release page before use
     EXPECTED_SHA256="f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158"
     ;;
 esac
 
-curl -L \
+curl -fL \
   -o "appimagetool-${APPIMAGE_ARCH}.AppImage" \
   "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_TAG}/appimagetool-${APPIMAGE_ARCH}.AppImage"
 

--- a/svg_to_drawio/elements/image.py
+++ b/svg_to_drawio/elements/image.py
@@ -134,8 +134,8 @@ def _resolve_image_href(ctx: EmitterContext, href: str | None) -> tuple[str | No
     asset_path = href
     if not path.isabs(asset_path):
         asset_path = path.join(ctx.source_dir, asset_path)
-    asset_path = path.abspath(path.normpath(asset_path))
-    base_dir = path.abspath(ctx.source_dir)
+    asset_path = path.realpath(path.abspath(path.normpath(asset_path)))
+    base_dir = path.realpath(path.abspath(ctx.source_dir))
     # Enforce containment check: local images must be within the trusted base directory
     try:
         if path.commonpath([base_dir, asset_path]) != base_dir:

--- a/svg_to_drawio_desktop/preview.py
+++ b/svg_to_drawio_desktop/preview.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import defusedxml.ElementTree as DefusedET
+from defusedxml.common import DefusedXmlException
 from PySide6.QtCore import QEvent, QPointF, QRectF, Qt, Signal
 from PySide6.QtGui import QColor, QImage, QMouseEvent, QPainter, QPaintEvent, QPen, QTransform, QWheelEvent
 from PySide6.QtSvg import QSvgRenderer
@@ -248,7 +249,7 @@ def _prepare_preview_svg(
     svg_file = Path(svg_path).resolve()
     try:
         root = DefusedET.parse(svg_file).getroot()
-    except ET.ParseError:
+    except (ET.ParseError, DefusedXmlException):
         return str(svg_file), None
 
     changed = False

--- a/svg_to_drawio_desktop/preview.py
+++ b/svg_to_drawio_desktop/preview.py
@@ -244,13 +244,13 @@ def _strip_style_elements(root: ET.Element) -> bool:
 
 def _prepare_preview_svg(
     svg_path: str, text_metrics_policy: str = "auto"
-) -> tuple[str, tempfile.TemporaryDirectory[str] | None]:
+) -> tuple[str | None, tempfile.TemporaryDirectory[str] | None]:
     """Normalize local image references so Qt can render the preview more faithfully."""
     svg_file = Path(svg_path).resolve()
     try:
         root = DefusedET.parse(svg_file).getroot()
     except (ET.ParseError, DefusedXmlException):
-        return str(svg_file), None
+        return None, None
 
     changed = False
     for elem in root.iter():
@@ -356,7 +356,7 @@ class SvgPreviewWidget(QWidget):
 
         renderer = QSvgRenderer(self)
         preview_path, temp_dir = _prepare_preview_svg(str(svg_file), text_metrics_policy)
-        if not renderer.load(preview_path):
+        if not preview_path or not renderer.load(preview_path):
             if temp_dir is not None:
                 temp_dir.cleanup()
             self._renderer = None

--- a/tests/unit/test_desktop_preview.py
+++ b/tests/unit/test_desktop_preview.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from svg_to_drawio_desktop.preview_selection import (
     preview_combo_index_to_report_index,
@@ -100,6 +101,30 @@ class DesktopPreviewTests(SvgTestCase):
         self.assertTrue(any(text.get("fill") == "#2563eb" for text in curved_glyphs))
         self.assertGreaterEqual(len(raised_glyphs), len("raised"))
         self.assertGreaterEqual(len(dropped_glyphs), len("dropped"))
+
+    def test_prepare_preview_svg_handles_malformed_xml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            svg_path = Path(tmpdir) / "malformed.svg"
+            svg_path.write_text('<svg xmlns="http://www.w3.org/2000/svg">', encoding="utf-8")
+
+            preview_path, temp_dir = _prepare_preview_svg(str(svg_path))
+
+        self.assertEqual(preview_path, str(svg_path.resolve()))
+        self.assertIsNone(temp_dir)
+
+    def test_prepare_preview_svg_handles_forbidden_xml_construct(self) -> None:
+        payload = """\
+        <!DOCTYPE svg [<!ENTITY forbidden "entity expansion">]>
+        <svg xmlns="http://www.w3.org/2000/svg"><text>&forbidden;</text></svg>
+        """
+        with TemporaryDirectory() as tmpdir:
+            svg_path = Path(tmpdir) / "forbidden-entity.svg"
+            svg_path.write_text(payload, encoding="utf-8")
+
+            preview_path, temp_dir = _prepare_preview_svg(str(svg_path))
+
+        self.assertEqual(preview_path, str(svg_path.resolve()))
+        self.assertIsNone(temp_dir)
 
 
 class PreviewSelectorHelperTests(SvgTestCase):

--- a/tests/unit/test_desktop_preview.py
+++ b/tests/unit/test_desktop_preview.py
@@ -109,7 +109,7 @@ class DesktopPreviewTests(SvgTestCase):
 
             preview_path, temp_dir = _prepare_preview_svg(str(svg_path))
 
-        self.assertEqual(preview_path, str(svg_path.resolve()))
+        self.assertIsNone(preview_path)
         self.assertIsNone(temp_dir)
 
     def test_prepare_preview_svg_handles_forbidden_xml_construct(self) -> None:
@@ -123,7 +123,7 @@ class DesktopPreviewTests(SvgTestCase):
 
             preview_path, temp_dir = _prepare_preview_svg(str(svg_path))
 
-        self.assertEqual(preview_path, str(svg_path.resolve()))
+        self.assertIsNone(preview_path)
         self.assertIsNone(temp_dir)
 
 

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import tempfile
-from os import path
+from os import path, symlink
 
 from tests.helpers import SvgTestCase
 
@@ -23,6 +23,56 @@ class ImageTests(SvgTestCase):
                 handle.write(b"not-a-real-png")
 
             root, _ = self._convert_in_dir(tmpdir, svg, rel_path=path.join("nested", "diagram.svg"))
+            self.assertEqual(self._user_cells(root), [])
+
+    def test_local_image_inside_source_dir_is_embedded(self) -> None:
+        svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <image href="asset.png" x="0" y="0" width="20" height="20" />
+        </svg>
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_path = path.join(tmpdir, "asset.png")
+            with open(asset_path, "wb") as handle:
+                handle.write(b"not-a-real-png")
+
+            root, _ = self._convert_in_dir(tmpdir, svg)
+            self.assertEqual(len(self._user_cells(root)), 1)
+
+    def test_local_image_symlink_to_internal_target_is_embedded(self) -> None:
+        svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <image href="asset-link.png" x="0" y="0" width="20" height="20" />
+        </svg>
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_path = path.join(tmpdir, "asset.png")
+            with open(asset_path, "wb") as handle:
+                handle.write(b"not-a-real-png")
+            try:
+                symlink(asset_path, path.join(tmpdir, "asset-link.png"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            root, _ = self._convert_in_dir(tmpdir, svg)
+            self.assertEqual(len(self._user_cells(root)), 1)
+
+    def test_local_image_symlink_to_external_target_is_rejected(self) -> None:
+        svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <image href="asset-link.png" x="0" y="0" width="20" height="20" />
+        </svg>
+        """
+        with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as outside_dir:
+            outside_asset = path.join(outside_dir, "secret.png")
+            with open(outside_asset, "wb") as handle:
+                handle.write(b"not-a-real-png")
+            try:
+                symlink(outside_asset, path.join(tmpdir, "asset-link.png"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            root, _ = self._convert_in_dir(tmpdir, svg)
             self.assertEqual(self._user_cells(root), [])
 
     def test_image_data_uri_preserve_aspect_ratio_none_and_rotation_are_mapped(self) -> None:


### PR DESCRIPTION
## What and why

This PR fixes the remaining regressions identified after the recent Aikido security changes, while preserving the protections already introduced.

- Handle malformed XML and XML constructs rejected by `defusedxml` in the desktop preview. `_prepare_preview_svg()` now returns cleanly instead of propagating `DefusedXmlException`.
- Prevent local image confinement checks from being bypassed through symbolic links. Both the trusted base directory and asset path are resolved with `realpath()` before applying `commonpath()`.
- Add regression coverage for normal local assets, path traversal, internal symlinks, external symlinks, malformed XML, and forbidden XML entities.
- Treat changes to `.github/workflows/desktop-build.yml` as desktop-relevant in CI.
- Make desktop release publication atomic by enforcing `build -> sign -> publish`. Release assets are uploaded only after signing and verification succeed.
- Preserve least-privilege workflow permissions:
  - Build jobs remain `contents: read`.
  - Signing uses `contents: read` and `id-token: write`.
  - Only the final publishing job receives `contents: write`.
  - Manual runs neither sign nor publish.
  - GPG secrets remain scoped to the steps that need them.
- Correct the AppImage documentation to use `appimagetool` 1.9.1, `curl -fL`, and the same SHA256 values as the packaging workflow.

## Checklist

- [x] `python -m unittest discover -s tests -v` passes — 245 tests
- [x] `python -m ruff check main.py svg_to_drawio svg_to_drawio_desktop tests` is clean
- [x] `python -m mypy` is clean
- [x] If conversion output changed: not applicable; conversion output is unchanged
- [x] If a CLI flag, Python API function, or default behavior changed: not applicable; no public CLI/API/default behavior changed
- [x] If a CLI flag, Python API function, or default behavior changed: not applicable; no GitHub Pages documentation update is required

Additional validation:

- `python -m pre_commit run --all-files --show-diff-on-failure` passes.
- YAML validation passes.
- No `if: secrets.` conditions.
- No global GPG secrets in build jobs.
- No `contents: write` permission in desktop build jobs.
- No `releases/download/continuous` reference.
- Manual desktop builds do not sign or publish.
- The release dependency chain is `build -> sign -> publish`.

## Fixture / behavior changes (if any)

No conversion fixtures changed. The conversion output format and normal image embedding behavior remain unchanged.

The intentional behavior changes are limited to security and failure handling:

- Malformed or security-rejected XML no longer crashes the desktop preview.
- Local image symlinks resolving outside the trusted base directory are rejected.
- Desktop release assets are published only after signing and verification complete successfully.